### PR TITLE
Fix bench (to use Id rather than Bytes)

### DIFF
--- a/negentropy/src/lib.rs
+++ b/negentropy/src/lib.rs
@@ -539,7 +539,7 @@ mod benches {
     use test::{black_box, Bencher};
 
     use super::storage::NegentropyStorageVector;
-    use super::Bytes;
+    use super::Id;
 
     #[bench]
     pub fn insert(bh: &mut Bencher) {
@@ -548,7 +548,7 @@ mod benches {
             black_box(
                 storage_client.insert(
                     0,
-                    Bytes::from_hex(
+                    Id::from_hex(
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                     )
                     .unwrap(),


### PR DESCRIPTION
### Description

`$ make bench` is broken because dommit 6e686b30ac6ad4789e65bd4b24dd38b7d1dffd1b failed to get everything.

(perhaps make precommit should do a make bench?)

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](../CONTRIBUTING.md)
* [x] I ran `make precommit` before committing